### PR TITLE
feat: add average time

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -2,12 +2,10 @@
 chrome.runtime.onMessage.addListener(
   function (request, sender, sendResponse) {
     // This cache stores page load time for each tab, so they don't interfere
-
     chrome.browserAction.setBadgeText({text: request.time, tabId: sender.tab.id});
     chrome.browserAction.setPopup({tabId: sender.tab.id, popup: "popup.html"});
     chrome.storage.sync.get(['performance'], (perf) => {
       var tmpPerf = Object.keys(perf).length ? perf : { performance: {} };
-      console.log('perf', request, sender, tmpPerf, perf, tmpPerf.performance.hasOwnProperty(request.location), tmpPerf[request.location], typeof tmpPerf[request.location]);
       if (tmpPerf.performance.hasOwnProperty(request.location)) {
         tmpPerf.performance[request.location].push(request);
       }
@@ -15,20 +13,10 @@ chrome.runtime.onMessage.addListener(
         tmpPerf.performance[request.location] = [request];
       }
       var dataToStore = { performance: tmpPerf.performance, currentPerf: request };
-      console.log('back', dataToStore);
       chrome.storage.sync.set(dataToStore, () => {
-        console.log('send message')
         chrome.runtime.sendMessage({ ...dataToStore, source: "background" });
         sendResponse();
       });
     });
   }
 );
-
-// cache eviction
-chrome.tabs.onRemoved.addListener(function(tabId) {
-  chrome.storage.local.get('cache', function(data) {
-    if (data.cache) delete data.cache['tab' + tabId];
-    chrome.storage.local.set(data);
-  });
-});

--- a/src/background.js
+++ b/src/background.js
@@ -1,14 +1,27 @@
 // Setting a toolbar badge text
 chrome.runtime.onMessage.addListener(
-  function(request, sender, sendResponse) {
+  function (request, sender, sendResponse) {
     // This cache stores page load time for each tab, so they don't interfere
-    chrome.storage.local.get('cache', function(data) {
-      if (!data.cache) data.cache = {};
-      data.cache['tab' + sender.tab.id] = request.timing;
-      chrome.storage.local.set(data);
-    });
+
     chrome.browserAction.setBadgeText({text: request.time, tabId: sender.tab.id});
-    chrome.browserAction.setPopup({tabId: sender.tab.id, popup: "popup.html"})
+    chrome.browserAction.setPopup({tabId: sender.tab.id, popup: "popup.html"});
+    chrome.storage.sync.get(['performance'], (perf) => {
+      var tmpPerf = Object.keys(perf).length ? perf : { performance: {} };
+      console.log('perf', request, sender, tmpPerf, perf, tmpPerf.performance.hasOwnProperty(request.location), tmpPerf[request.location], typeof tmpPerf[request.location]);
+      if (tmpPerf.performance.hasOwnProperty(request.location)) {
+        tmpPerf.performance[request.location].push(request);
+      }
+      else {
+        tmpPerf.performance[request.location] = [request];
+      }
+      var dataToStore = { performance: tmpPerf.performance, currentPerf: request };
+      console.log('back', dataToStore);
+      chrome.storage.sync.set(dataToStore, () => {
+        console.log('send message')
+        chrome.runtime.sendMessage({ ...dataToStore, source: "background" });
+        sendResponse();
+      });
+    });
   }
 );
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,6 @@
     "js": ["performance.js"]
   }],
   "permissions": [
-    "activeTab",
     "storage"
   ],
   "icons": {

--- a/src/performance.js
+++ b/src/performance.js
@@ -13,7 +13,13 @@
       if (l.duration > 0) {
         // we have only 4 chars in our disposal including decimal point
         var t = (l.duration / 1000).toFixed(2);
-        chrome.runtime.sendMessage({time: t, timing: l});
+        var res = {
+          location: window.location.href,
+          date: (new Date()).toDateString(),
+          time: t,
+          timing: l
+        }
+        chrome.runtime.sendMessage(res);
       }
     }, 0);
   }

--- a/src/performance.js
+++ b/src/performance.js
@@ -18,7 +18,7 @@
           date: (new Date()).toDateString(),
           time: t,
           timing: l
-        }
+        };
         chrome.runtime.sendMessage(res);
       }
     }, 0);

--- a/src/popup.css
+++ b/src/popup.css
@@ -43,11 +43,6 @@ span:last-child {
 #header span:first-child {
     text-align: left;
 }
-.row {
-    background-image: -webkit-gradient(linear, left bottom, left top,
-        color-stop(0, #c3e0ee), color-stop(0, #c3e0ee));
-    background-repeat: no-repeat;
-}
 h3 {
     font-size: 16px;
     color: rgba(0,0,0,.54);

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,73 +1,105 @@
 <!DOCTYPE html>
-<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
-<link rel="stylesheet" href="popup.css">
-<script src="polyfill.js"></script>
-<script src="popup.js"></script>
-
-<h3>Load timings (ms)</h3>
-<div id="container">
-    <div id="header">
-        <span>Event</span>
-        <span>Start</span>
-        <span>Duration</span>
-        <span>End</span>
+<html>
+  <head>
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
+    <link rel="stylesheet" href="popup.css">
+  </head>
+  <body>
+    <div class="">
+        <h3>Load timings (ms)</h3>
+        <div id="container">
+            <div id="header">
+                <span>Event</span>
+                <span>Start</span>
+                <span>Duration</span>
+                <span>End</span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-redirect">
+                <span>Redirect</span>
+                <span id="redirectWhen"></span>
+                <span id="redirect"></span>
+                <span id="redirectTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-dns">
+                <span>DNS</span>
+                <span id="dnsWhen"></span>
+                <span id="dns"></span>
+                <span id="dnsTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-connect">
+                <span>Connect</span>
+                <span id="connectWhen"></span>
+                <span id="connect"></span>
+                <span id="connectTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-request">
+                <span>Request</span>
+                <span id="requestWhen"></span>
+                <span id="request"></span>
+                <span id="requestTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-response">
+                <span>Response</span>
+                <span id="responseWhen"></span>
+                <span id="response"></span>
+                <span id="responseTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-dom">
+                <span>DOM</span>
+                <span id="domWhen"></span>
+                <span id="dom"></span>
+                <span id="domTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-domInteractive">
+                <span class="sub">Interactive</span>
+                <span id="domInteractiveWhen"></span>
+                <span id="domInteractive"></span>
+                <span id="domInteractiveTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-contentLoaded">
+                <span class="sub">Content loaded</span>
+                <span id="contentLoadedWhen"></span>
+                <span id="contentLoaded"></span>
+                <span id="contentLoadedTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-load">
+                <span>Load event</span>
+                <span id="loadWhen"></span>
+                <span id="load"></span>
+                <span id="loadTotal"></span>
+                <div class="current-perf"></div>
+                <div class="average-perf"></div>
+            </div>
+            <div class="row" id="r-total">
+                <span>Total</span>
+                <span id="total"></span>
+            </div>
+        </div>
     </div>
-    <div class="row" id="r-redirect">
-        <span>Redirect</span>
-        <span id="redirectWhen"></span>
-        <span id="redirect"></span>
-        <span id="redirectTotal"></span>
+    <div class="">
+        <input type="search" name="search" list="locations" id="search" />
+        <datalist id="locations_href"></datalist>
+        <datalist id="locations_domaine"></datalist>
     </div>
-    <div class="row" id="r-dns">
-        <span>DNS</span>
-        <span id="dnsWhen"></span>
-        <span id="dns"></span>
-        <span id="dnsTotal"></span>
-    </div>
-    <div class="row" id="r-connect">
-        <span>Connect</span>
-        <span id="connectWhen"></span>
-        <span id="connect"></span>
-        <span id="connectTotal"></span>
-    </div>
-    <div class="row" id="r-request">
-        <span>Request</span>
-        <span id="requestWhen"></span>
-        <span id="request"></span>
-        <span id="requestTotal"></span>
-    </div>
-    <div class="row" id="r-response">
-        <span>Response</span>
-        <span id="responseWhen"></span>
-        <span id="response"></span>
-        <span id="responseTotal"></span>
-    </div>
-    <div class="row" id="r-dom">
-        <span>DOM</span>
-        <span id="domWhen"></span>
-        <span id="dom"></span>
-        <span id="domTotal"></span>
-    </div>
-    <div class="row" id="r-domInteractive">
-        <span class="sub">Interactive</span>
-        <span id="domInteractiveWhen"></span>
-        <span id="domInteractive"></span>
-        <span id="domInteractiveTotal"></span>
-    </div>
-    <div class="row" id="r-contentLoaded">
-        <span class="sub">Content loaded</span>
-        <span id="contentLoadedWhen"></span>
-        <span id="contentLoaded"></span>
-        <span id="contentLoadedTotal"></span>
-    </div>
-    <div class="row" id="r-load">
-        <span>Load event</span>
-        <span id="loadWhen"></span>
-        <span id="load"></span>
-        <span id="loadTotal"></span>
-    </div>
-    <div class="row" id="r-total">
-        <span>Total</span>
-        <span id="total"></span>
-    </div>
-</div>
+    <script src="polyfill.js"></script>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -26,8 +26,6 @@ function set(id, total, current, noacc, avg, avgTotal) {
   document.getElementById(id).innerHTML = length;
   document.getElementById(id + 'Total').innerHTML = noacc ? '-' : Math.round(current.end);
   document.getElementById('r-' + id).style.cssText = 'position:relative;';
-  //   'background-size:' + Math.round(length / total * 300) + 'px 100%;' +
-  //   'background-position-x:' + (x >= 300 ? 299 : x) + 'px;';
 }
 
 function updatePageTime(performanceData, datas) {
@@ -117,7 +115,7 @@ function updatePageTime(performanceData, datas) {
         sumObj.contentLoaded.end /= nbrElem;
         sumObj.duration /= nbrElem;
       }
-      return sumObj
+      return sumObj;
     }, {
       redirect: {
         start: 0,
@@ -157,7 +155,6 @@ function updatePageTime(performanceData, datas) {
       },
       duration: 0,
     });
-    console.log('average', average);
   }
 
   // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#processing-model
@@ -177,7 +174,6 @@ var checkReady = setInterval(() => {
     clearInterval(checkReady);
     chrome.runtime.onMessage.addListener(
       function (request, sender, sendResponse) {
-        console.log('popup', request, sender, window.location);
         if (request.source === "background") {
           updatePageTime(request.currentPerf.timing, request.performance[request.currentPerf.location]);
         }

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,31 +1,191 @@
-var total = 0;
+function set(id, total, current, noacc, avg, avgTotal) {
+  var length = Math.round(current.end - current.start);
+  var x = Math.round(current.start / total * 100);
+  document.getElementById(id + 'When').innerHTML = Math.round(current.start);
+  document.querySelector('#r-' + id + ' .current-perf').style.cssText =
+    'position: absolute;' +
+    'top: 0;' +
+    'bottom: 50%;' +
+    'width: ' + Math.round(length / total * 100) + '%;' +
+    'background-color: orange;' +
+    'opacity: .5;' +
+    'left: ' + x + '%;';
+  if (typeof avg !== 'undefined') {
+    avg.length = Math.round(avg.end - avg.start);
+    avg.x = Math.round(avg.start / avgTotal * 100);
+    document.querySelector('#r-' + id + ' .average-perf').style.cssText =
+      'position: absolute;' +
+      'top: 50%;' +
+      'bottom: 0;' +
+      'width: ' + Math.round(avg.length / avgTotal * 100) + '%;' +
+      'background-color: green;' +
+      'opacity: .5;' +
+      'left: ' + avg.x + '%;';
+  }
 
-function set(id, start, end, noacc) {
-  var length = Math.round(end - start);
-  var x = Math.round(start / total * 300);
-  document.getElementById(id + 'When').innerHTML = Math.round(start);
   document.getElementById(id).innerHTML = length;
-  document.getElementById(id + 'Total').innerHTML = noacc ? '-' : Math.round(end);
-  document.getElementById('r-' + id).style.cssText =
-    'background-size:' + Math.round(length / total * 300) + 'px 100%;' +
-    'background-position-x:' + (x >= 300 ? 299 : x) + 'px;';
+  document.getElementById(id + 'Total').innerHTML = noacc ? '-' : Math.round(current.end);
+  document.getElementById('r-' + id).style.cssText = 'position:relative;';
+  //   'background-size:' + Math.round(length / total * 300) + 'px 100%;' +
+  //   'background-position-x:' + (x >= 300 ? 299 : x) + 'px;';
 }
 
-getSelectedTab(function(tab) {
-  storageLocal().get('cache', function(data) {
-    var t = data.cache['tab' + tab.id];
-    total = t.duration;
+function updatePageTime(performanceData, datas) {
+  var total = performanceData.duration;
+  var currentData = {
+    redirect: {
+      start: performanceData.redirectStart,
+      end: performanceData.redirectEnd,
+    },
+    dns: {
+      start: performanceData.domainLookupStart,
+      end: performanceData.domainLookupEnd
+    },
+    connect: {
+      start: performanceData.connectStart,
+      end: performanceData.connectEnd
+    },
+    request: {
+      start: performanceData.requestStart,
+      end: performanceData.responseStart
+    },
+    response: {
+      start: performanceData.responseStart,
+      end: performanceData.responseEnd
+    },
+    dom: {
+      start: performanceData.responseStart,
+      end: performanceData.domComplete
+    },
+    domInteractive: {
+      start: performanceData.domInteractive,
+      end: performanceData.domInteractive
+    },
+    contentLoaded: {
+      start: performanceData.domContentLoadedEventStart,
+      end: performanceData.domContentLoadedEventEnd
+    },
+    load: {
+      start: performanceData.loadEventStart,
+      end: performanceData.loadEventEnd
+    },
+    duration: 0,
+  };
 
-    // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#processing-model
-    set('redirect', t.redirectStart, t.redirectEnd);
-    set('dns', t.domainLookupStart, t.domainLookupEnd);
-    set('connect', t.connectStart, t.connectEnd);
-    set('request', t.requestStart, t.responseStart);
-    set('response', t.responseStart, t.responseEnd);
-    set('dom', t.responseStart, t.domComplete);
-    set('domInteractive', t.domInteractive, t.domInteractive, true);
-    set('contentLoaded', t.domContentLoadedEventStart, t.domContentLoadedEventEnd, true);
-    set('load', t.loadEventStart, t.loadEventEnd);
-    document.getElementById("total").innerHTML = Math.round(t.duration);
-  });
+  var average = {};
+  if (typeof datas !== 'undefined') {
+    var nbrElem = datas.length;
+    average = datas.reduce(function (sumObj, data, index) {
+      sumObj.load.start += data.timing.loadEventStart;
+      sumObj.load.end += data.timing.loadEventEnd;
+      sumObj.redirect.start += data.timing.redirectEnd;
+      sumObj.redirect.end += data.timing.redirectEnd;
+      sumObj.dns.start += data.timing.domainLookupStart;
+      sumObj.dns.end += data.timing.domainLookupEnd;
+      sumObj.connect.start += data.timing.connectStart;
+      sumObj.connect.end += data.timing.connectEnd;
+      sumObj.request.start += data.timing.requestStart;
+      sumObj.request.end += data.timing.responseStart;
+      sumObj.response.start += data.timing.responseStart;
+      sumObj.response.end += data.timing.responseEnd;
+      sumObj.dom.start += data.timing.responseStart;
+      sumObj.dom.end += data.timing.domComplete;
+      sumObj.domInteractive.start += data.timing.domInteractive;
+      sumObj.domInteractive.end += data.timing.domInteractive;
+      sumObj.contentLoaded.start += data.timing.domContentLoadedEventStart;
+      sumObj.contentLoaded.end += data.timing.domContentLoadedEventEnd;
+      sumObj.duration += data.timing.duration;
+
+      if ((index + 1) === nbrElem) {
+        sumObj.load.start /= nbrElem;
+        sumObj.load.end /= nbrElem;
+        sumObj.redirect.start /= nbrElem;
+        sumObj.redirect.end /= nbrElem;
+        sumObj.dns.start /= nbrElem;
+        sumObj.dns.end /= nbrElem;
+        sumObj.connect.start /= nbrElem;
+        sumObj.connect.end /= nbrElem;
+        sumObj.request.start /= nbrElem;
+        sumObj.request.end /= nbrElem;
+        sumObj.response.start /= nbrElem;
+        sumObj.response.end /= nbrElem;
+        sumObj.dom.start /= nbrElem;
+        sumObj.dom.end /= nbrElem;
+        sumObj.domInteractive.start /= nbrElem;
+        sumObj.domInteractive.end /= nbrElem;
+        sumObj.contentLoaded.start /= nbrElem;
+        sumObj.contentLoaded.end /= nbrElem;
+        sumObj.duration /= nbrElem;
+      }
+      return sumObj
+    }, {
+      redirect: {
+        start: 0,
+        end: 0,
+      },
+      dns: {
+        start: 0,
+        end: 0,
+      },
+      connect: {
+        start: 0,
+        end: 0,
+      },
+      request: {
+        start: 0,
+        end: 0,
+      },
+      response: {
+        start: 0,
+        end: 0,
+      },
+      dom: {
+        start: 0,
+        end: 0,
+      },
+      domInteractive: {
+        start: 0,
+        end: 0,
+      },
+      contentLoaded: {
+        start: 0,
+        end: 0,
+      },
+      load: {
+        start: 0,
+        end: 0,
+      },
+      duration: 0,
+    });
+    console.log('average', average);
+  }
+
+  // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#processing-model
+  set('redirect', total, currentData.redirect, false, average.redirect, average.duration);
+  set('dns', total, currentData.dns, false, average.dns, average.duration);
+  set('connect', total, currentData.connect, false, average.connect, average.duration);
+  set('request', total, currentData.request, false, average.request, average.duration);
+  set('response', total, currentData.response, false, average.response, average.duration);
+  set('dom', total, currentData.dom, false, average.dom, average.duration);
+  set('domInteractive', total, currentData.domInteractive, true, average.domInteractive, average.duration);
+  set('contentLoaded', total, currentData.contentLoaded, true, average.contentLoaded, average.duration);
+  document.getElementById("total").innerHTML = Math.round(performanceData.duration) + ' / ' + Math.round(average.duration);
+}
+
+var checkReady = setInterval(() => {
+  if (document.readyState === "complete") {
+    clearInterval(checkReady);
+    chrome.runtime.onMessage.addListener(
+      function (request, sender, sendResponse) {
+        console.log('popup', request, sender, window.location);
+        if (request.source === "background") {
+          updatePageTime(request.currentPerf.timing, request.performance[request.currentPerf.location]);
+        }
+        else {
+          // Loading page
+          updatePageTime(request.timing);
+        }
+      }
+    );
+  }
 });


### PR DESCRIPTION
This PR attempts to track average time per website #19 

## Implementation

This is done by storing the performance on every page with an array of performance which will be used by the popin.
The popin displays the graph of time performance of the page in the orange color, below it in the green color the average time of this page.

## Going further

- possibility to reset that data store (chrome may through an exception because too many things are stored)
- possibility to track only a / some website by adding an option page by example
- possibility to group the tracking (by domain for instance)